### PR TITLE
CVE-2018-18074

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gunicorn==19.9.0
 ItsDangerous==0.24
 jsonpickle==0.9.6
 psycopg2-binary==2.7.5
-requests==2.19.1
+requests==2.20.0
 SQLAlchemy==1.2.11
 sqlparse==0.2.4
 termcolor==1.1.0


### PR DESCRIPTION
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.